### PR TITLE
__all__ variable seems to be malformed

### DIFF
--- a/crew/worker/listener.py
+++ b/crew/worker/listener.py
@@ -228,4 +228,4 @@ class Listener(object):
 
 
 
-__all__ = (Listener)
+__all__ = ("Listener",)


### PR DESCRIPTION
```
>>> from crew.worker.listener import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'type' object does not support indexing
```
If I understand right, `__all__ ` must be a list (or tuple) of strings that declare names available via `from listener import *`.